### PR TITLE
Issue Fix - Switching To the storage page takes a lot of time when POS is not running

### DIFF
--- a/src/mtool/api/UnitTests/StorageManagement/test_storage.py
+++ b/src/mtool/api/UnitTests/StorageManagement/test_storage.py
@@ -1851,6 +1851,9 @@ def test_list_devices(global_data, **kwargs):
                              "data": {"devicelist": [{"name": "unvme-ns-0",
                                                       "type": "NVRAM"}]}},
                        status_code=200)
+    kwargs["mock"].get(DAGENT_URL + '/api/ibofos/v1/devices/all/scan',
+                       json={"result": {"status": {"description": "SUCCESS"}}},
+                       status_code=200)
     kwargs["mock"].get(ARRAY_LIST_URL,
                        json={
     "rid": "354220f5-60b5-4e27-ba44-e4b4b34434f3",

--- a/src/mtool/api/rest/rest_api/dagent/ibofos.py
+++ b/src/mtool/api/rest/rest_api/dagent/ibofos.py
@@ -93,7 +93,7 @@ def send_command_to_dagent(req_type, url, headers, timeout=None, data=None):
                 return response
             if response.status_code == 202 or response.status_code == 503:
                 retry_count = 5
-            if(retry_count >= 5):
+            if(retry_count >= 1): # Removing retry logic as D-Agent has locks implemented
                 return response
             time.sleep(1)
     except BaseException:

--- a/src/mtool/api/rest/rest_api/device/device.py
+++ b/src/mtool/api/rest/rest_api/device/device.py
@@ -42,7 +42,9 @@ def list_devices():
     #scan_dev = scan_devices()
     # if scan_dev.status_code != 200:
     #    return scan_dev
-    scan_devices()
+    scan = scan_devices()
+    if scan.status_code != 200:
+        return scan
     devices = get_devices()
     devices = devices.json()
     if "return" in devices and devices["return"] == -1:

--- a/src/mtool/ui/src/sagas/storageSaga.js
+++ b/src/mtool/ui/src/sagas/storageSaga.js
@@ -190,6 +190,7 @@ function* fetchDevices(action) {
     devices: [],
     metadevices: [],
   };
+  let fetchDeviceSuccess = false;
   const alertDetails = {
     errorMsg: "Unable to get devices!",
     alertType: "alert",
@@ -222,6 +223,7 @@ function* fetchDevices(action) {
         })
       );
     } else if (result && typeof result !== "string" && result.return !== -1) {
+      fetchDeviceSuccess = true;
       yield put(actionCreators.fetchDevices(result));
     } else {
       yield put(actionCreators.showStorageAlert({
@@ -241,7 +243,9 @@ function* fetchDevices(action) {
     }));
     yield put(actionCreators.fetchDevices(defaultResponse));
   } finally {
-    if (!action || !action.payload || !action.payload.noLoad) {
+    if(!fetchDeviceSuccess) {
+      yield put(actionCreators.stopStorageLoader());
+    } else if (!action || !action.payload || !action.payload.noLoad) {
       yield put(actionCreators.stopStorageLoader());
       yield fetchArray();
     } else {


### PR DESCRIPTION
Removed the Retry logic in API server - Not required as lock is present in D-Agent
Added Check for scan device API response before calling list Device
Prevent further API calls in case list device fails in normal scenario